### PR TITLE
Kubernetes Nodes fail to come in the tip, kubelet depricated --config switch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ node:
     --allow-privileged
     --cluster-dns=${DNS_SERVER_IP}
     --cluster-domain=${DNS_DOMAIN}
-    --config=/var/lib/kubelet/manifests
+    --pod-manifest-path=/var/lib/kubelet/manifests
     --v=5 2>&1 | sed 's/^/kubelet: /' 1>&2 &
     hyperkube proxy
     --hostname-override=$${HOSTNAME_OVERRIDE}


### PR DESCRIPTION
Kubelet's options have changed and have started to throw errors like below, this prevented nodes from comming up.  removing the 

```
kubelet: Error: unknown flag: --config
kubelet:
kubelet: The kubelet binary is responsible for maintaining a set of containers on a
kubelet:
kubelet:   particular node. It syncs data from a variety of sources including a
kubelet:   Kubernetes API server, an etcd cluster, HTTP endpoint or local file. It then
kubelet:   queries Docker to see what is currently running.  It synchronizes the
kubelet:   configuration data, with the running set of containers by starting or stopping
kubelet:   Docker containers.
kubelet: Usage:
kubelet:   kubelet [flags]
kubelet:
kubelet: Available Flags:
```

https://github.com/kubernetes/kubernetes/pull/40048