### PR TITLE
Fix obsolete --all flag and add -v flag

### DIFF
--- a/dind-up-cluster.sh
+++ b/dind-up-cluster.sh
@@ -229,7 +229,7 @@ function dind::kube-down {
   dind::step "Stopping dind cluster"
   # Since restoring a stopped cluster is not yet supported, use the nuclear option
   dind::docker_compose kill
-  dind::docker_compose rm -f --all
+  dind::docker_compose rm -f -v
 }
 
 # Waits for a kube-system pod (of the provided name) to have the phase/status "Running".


### PR DESCRIPTION
Flag --all is obsolete. This is now the
default behavior of `docker-compose rm`.
Remove it.

Add flag -v. Remove any anonymous volumes\
attached to containers.